### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Download hakoniwa-core-cpp for Linux
         if:  " (runner.os == 'Linux')"
         run: |
-          wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.1/libshakoc.so -P /usr/local/lib/hakoniwa/
+          sudo wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.1/libshakoc.so -P /usr/local/lib/hakoniwa/
           sudo apt-get update
           sudo apt-get install -y libc++-dev libc++abi-dev
 
       - name: Download hakoniwa-core-cpp for Mac(intell)
         if:  " (runner.os == 'macOS')"
         run: |
-          wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.0/libshakoc.dylib -P /usr/local/lib/hakoniwa/
+          sudo wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.0/libshakoc.dylib -P /usr/local/lib/hakoniwa/
 
       - name: Build hakoniwa-conductor
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      - name: Download hakoniwa-core-cpp for Linux
+        if:  " (runner.os == 'Linux')"
+        run: |
+          wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.1/libshakoc.so -P /usr/local/lib/hakoniwa/
+          sudo apt-get update
+          sudo apt-get install -y libc++-dev libc++abi-dev
+
+      - name: Download hakoniwa-core-cpp for Mac(intell)
+        if:  " (runner.os == 'macOS')"
+        run: |
+          wget https://github.com/toppers/hakoniwa-core-cpp-client/releases/download/v1.0.0/libshakoc.dylib -P /usr/local/lib/hakoniwa/
+
+      - name: Build hakoniwa-conductor
+        run: |
+          cd main
+          bash build.bash

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build](https://github.com/toppers/hakoniwa-conductor/actions/workflows/build.yml/badge.svg)](https://github.com/toppers/hakoniwa-conductor/actions/workflows/build.yml)
+
 # hakoniwa-conductor


### PR DESCRIPTION
GitHub Actionsでのビルド環境を作成しました。
いくつか制限事項があります。
- hakoniwa-core-cpp-clientのライブラリが必要ですが、これはライブラリのバイナリをダウンロードしています(これもビルドしたほうがいいのかもしれません)
- Pythonのバージョンを3.10の固定にしています